### PR TITLE
Removed unused error class

### DIFF
--- a/lib/data_classification.rb
+++ b/lib/data_classification.rb
@@ -4,7 +4,6 @@ require "data_classification/generators/data_classification/create_generator"
 
 module DataClassification
   require 'data_classification/railtie' if defined?(Rails)
-  class Error < StandardError; end
 
   DATA_CLASSIFICATIONS = [
     PUBLIC = :public,


### PR DESCRIPTION
This was locally causing issues in specs, looks like it was (somehow) conflicting with approvals. Not needed so removing.